### PR TITLE
Modify encoding and padding 

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch.utils.data as Data
 from numpy import random
 
@@ -6,8 +7,10 @@ def data_generator(codebook, seq_len, data_num):
     alphabet = [0, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
                 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z']
     res = []
+
     data = random.randint(1, 27, (data_num, seq_len))
     data_t = []
+    data_t_replace = []
     for i in range(data_num):
         in_s = ""
         in_d = data[i]
@@ -15,9 +18,18 @@ def data_generator(codebook, seq_len, data_num):
         out_s = ""
         out_s = out_s.join(codebook[alphabet[order]] for order in in_d)
         out_d = [int(k) for k in out_s]
-        res.append([in_s, in_d, out_s, out_d])
-        data_t.append(out_d)
-    return res, data, data_t
+        out_dd = [int(k) for k in out_s]
+        while len(out_dd) < 50:
+            out_dd.append(2)
+            out_s += '2'
+        res.append([in_s, in_d, out_s, out_dd])
+        data_t.append(out_dd)
+        # replace##### 0 is zero-grad
+        out_d = [2 if x == 0 else x for x in out_d]
+        while len(out_d) < 50:
+            out_d.append(3)
+        data_t_replace.append(out_d)
+    return res, data, data_t, data_t_replace
 
 
 # Used for drawing to rotate the x-axis and y-axis


### PR DESCRIPTION
Mainly modified two parts: 
1.Padding is added at the end of the 4-bit huffman character  ---> padding is added at the end of the entire sequence 
2.Use 1 and 2 for Huffman coding, use 0 as padding ------> Use 0 and 1 for Huffman coding 

Final Results ：
For a random sequence of length 10 ：
![C9TGM$T5`16 )3`)V}F7RMW](https://user-images.githubusercontent.com/91429283/157573984-1346fb9d-2a2e-4894-85e7-60b37a8c2744.png)
The effect is very good, the sequence generated by the model is consistent with the correct sequence, but his attention map is very different from the expected. 
![867IFV_R%_~MJW6 CYFSU7V](https://user-images.githubusercontent.com/91429283/157574298-1242770d-53bd-4d4e-813e-e3c22c7df069.png)
It can even be said that the results of the attention map are confusing :(